### PR TITLE
Update test plugin to accept arguments

### DIFF
--- a/root.go
+++ b/root.go
@@ -39,7 +39,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return runTestCmd(projectDirFlagVal, tagsFlagVal, junitOutputFlagVal, param, cmd.OutOrStdout())
+		return runTestCmd(projectDirFlagVal, args, tagsFlagVal, junitOutputFlagVal, param, cmd.OutOrStdout())
 	},
 }
 

--- a/test.go
+++ b/test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func runTestCmd(projectDir string, tags []string, junitOutput string, param TestParam, stdout io.Writer) (rErr error) {
+func runTestCmd(projectDir string, testArgs, tags []string, junitOutput string, param TestParam, stdout io.Writer) (rErr error) {
 	if err := param.Validate(); err != nil {
 		return err
 	}
@@ -41,8 +41,10 @@ func runTestCmd(projectDir string, tags []string, junitOutput string, param Test
 		return errors.Errorf("no packages to test")
 	}
 
-	var args []string
-	args = append(args, "test")
+	args := []string{
+		"test",
+	}
+	args = append(args, testArgs...)
 
 	if junitOutput != "" {
 		args = append(args, "-v")


### PR DESCRIPTION
Arguments provided to the "test" task are passed directly to the
"go test" command before the packages. This allows "./godelw test"
to use any flags for "go test".