### PR TITLE
Add run subcommand

### DIFF
--- a/run.go
+++ b/run.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run tests using the provided arguments",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		param, err := testParamFromFlags(testConfigFileFlagVal, godelConfigFileFlagVal)
+		if err != nil {
+			return err
+		}
+		return runTestCmd(projectDirFlagVal, args, tagsFlagVal, junitOutputFlagVal, param, cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	runCmd.Flags().StringSliceVar(&tagsFlagVal, "tags", nil, "run tests that are part of the provided tags")
+	rootCmd.AddCommand(runCmd)
+}


### PR DESCRIPTION
Adds "run" subcommand that can be used to run tests while passing
flags/arguments directly to "go test".