### PR TITLE
Update logic that lists packages for tests

### DIFF
--- a/changelog/@unreleased/pr-336.v2.yml
+++ b/changelog/@unreleased/pr-336.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Updates logic that lists packages for tests to only match packages
+    that match the module of the root directory of the project.
+  links:
+  - https://github.com/palantir/godel-test-plugin/pull/336

--- a/testplugin/test.go
+++ b/testplugin/test.go
@@ -207,7 +207,7 @@ func matcherForTags(tags []string, cfg TestParam) (matcher.Matcher, error) {
 // pkgPaths returns a slice that contains the relative package paths for all of the packages in the provided project
 // directory relative to the project directory excluding any of the paths that match the provided "exclude" Matcher.
 func pkgPaths(projectDir string, exclude matcher.Matcher) ([]string, error) {
-	pkgs, err := pkgpath.PackagesInDir(projectDir, exclude)
+	pkgs, err := pkgpath.PackagesInDirMatchingRootModule(projectDir, exclude)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list packages in %s", projectDir)
 	}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates logic that lists packages for tests to only match packages that match the module of the root directory of the project.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

