### PR TITLE
Fail test task if "go test" execution fails

### DIFF
--- a/testplugin/test.go
+++ b/testplugin/test.go
@@ -15,6 +15,7 @@
 package testplugin
 
 import (
+	goerrors "errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -70,15 +71,21 @@ func RunTestCmd(projectDir string, testArgs, tags []string, junitOutput string, 
 
 	failedPkgs, err := executeTestCmd(cmd, stdout, rawOutputWriter, maxPkgLen)
 
-	if err != nil && err.Error() != "exit status 1" {
-		// only re-throw if error is not "exit status 1", since those errors are generally recoverable
-		return err
-	}
-
 	if len(failedPkgs) > 0 {
 		numFailedPkgs := len(failedPkgs)
 		outputParts := append([]string{fmt.Sprintf("%d package(s) had failing tests:", numFailedPkgs)}, failedPkgs...)
 		return errors.Errorf("%s", strings.Join(outputParts, "\n\t"))
+	}
+
+	// the exit status of "go test" is the authoritative signal for whether the tests succeeded: the
+	// packages parsed out of the command's output are only used to provide a more useful error
+	// message. A non-zero exit status with no parsed failures occurs for cases such as packages that
+	// fail to compile (where the output does not contain a parseable "FAIL" summary line).
+	if err != nil {
+		if exitErr, ok := goerrors.AsType[*exec.ExitError](err); ok {
+			return errors.Wrapf(exitErr, `"go test" failed and no failing packages were detected in its output`)
+		}
+		return err
 	}
 
 	return nil

--- a/testplugin/test_test.go
+++ b/testplugin/test_test.go
@@ -24,6 +24,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRunTestCmdReturnsErrorForBuildFailureWithoutParsedPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module testmod\n\ngo 1.21\n"), 0644))
+
+	pkgDir := filepath.Join(tmpDir, "pkgbad")
+	require.NoError(t, os.MkdirAll(pkgDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "pkgbad.go"), []byte("package pkgbad\n\nvar _ = undefined\n"), 0644))
+
+	var stdout bytes.Buffer
+	err := RunTestCmd(tmpDir, nil, nil, "", nil, TestParam{}, &stdout)
+
+	require.EqualError(t, err, `"go test" failed and no failing packages were detected in its output: exit status 1`)
+	assert.Contains(t, stdout.String(), "FAIL\ttestmod/pkgbad [build failed]")
+}
+
 func TestPkgsToTest(t *testing.T) {
 	// Create a temp directory with some Go packages for testing
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where "go test" failing with a non-0 exit code but in a manner where failed packages could not be parsed from output would cause the "test" task to report as successful.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

