### PR TITLE
Fix test failure parsing logic to be resilient to buffer issues

### DIFF
--- a/testplugin/runner.go
+++ b/testplugin/runner.go
@@ -16,6 +16,7 @@ package testplugin
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"os/exec"
 	"regexp"
@@ -74,6 +75,10 @@ func executeTestCmd(execCmd *exec.Cmd, stdout, rawOutputWriter io.Writer, longes
 
 	// run command (which will print its Stdout and Stderr to the Stdout of current process) and return output
 	err := execCmd.Run()
+	// process any trailing output that was not terminated by a newline
+	if flushErr := multiWriter.Flush(); flushErr != nil && err == nil {
+		err = flushErr
+	}
 	return multiWriter.failedPkgs, err
 }
 
@@ -82,6 +87,9 @@ type multiWriter struct {
 	rawOutputWriter   io.Writer
 	failedPkgs        []string
 	longestPkgNameLen int
+	// partial line from the end of the previous Write call. The writes performed by the command are
+	// not guaranteed to be line-aligned, so a line may be split across multiple Write calls.
+	pendingLine []byte
 }
 
 var setupFailedRegexp = regexp.MustCompile(`(^FAIL\t.+) (\[setup failed\]$)`)
@@ -93,7 +101,43 @@ func (w *multiWriter) Write(p []byte) (int, error) {
 		return n, err
 	}
 
-	lines := strings.Split(string(p), "\n")
+	// only process complete lines: buffer any trailing partial line and prepend it to the content of
+	// the next Write call so that a line that is split across Write calls is still processed as a
+	// single line.
+	buf := append(w.pendingLine, p...)
+	lastNewlineIdx := bytes.LastIndexByte(buf, '\n')
+	if lastNewlineIdx == -1 {
+		// no complete line is available: buffer all content and wait for more
+		w.pendingLine = buf
+		return n, err
+	}
+	// copy the remainder because "p" must not be retained after Write returns
+	w.pendingLine = append([]byte(nil), buf[lastNewlineIdx+1:]...)
+
+	if _, err := w.consoleWriter.Write([]byte(w.processLines(string(buf[:lastNewlineIdx+1])))); err != nil {
+		return n, err
+	}
+
+	// n and err are from the unaltered write to the rawOutputWriter
+	return n, err
+}
+
+// Flush processes and writes any buffered content that was not terminated by a newline. It must be
+// called after the command that writes to this writer has completed.
+func (w *multiWriter) Flush() error {
+	if len(w.pendingLine) == 0 {
+		return nil
+	}
+	pendingLine := string(w.pendingLine)
+	w.pendingLine = nil
+	_, err := w.consoleWriter.Write([]byte(w.processLines(pendingLine)))
+	return err
+}
+
+// processLines aligns the package summary lines in the provided content and records the packages
+// that had failures in "failedPkgs". Returns the content with the summary lines aligned.
+func (w *multiWriter) processLines(content string) string {
+	lines := strings.Split(content, "\n")
 	for i, currLine := range lines {
 		// test output for valid case always starts with "Ok" or "FAIL"
 		if strings.HasPrefix(currLine, "ok") || strings.HasPrefix(currLine, "FAIL") || strings.HasPrefix(currLine, "?") {
@@ -118,13 +162,7 @@ func (w *multiWriter) Write(p []byte) (int, error) {
 		}
 	}
 
-	// write formatted version to console writer
-	if n, err := w.consoleWriter.Write([]byte(strings.Join(lines, "\n"))); err != nil {
-		return n, err
-	}
-
-	// n and err are from the unaltered write to the rawOutputWriter
-	return n, err
+	return strings.Join(lines, "\n")
 }
 
 // alignLine returns a string where the length of the second field (fields[1]) is padded with spaces to make its length

--- a/testplugin/runner_test.go
+++ b/testplugin/runner_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testplugin
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiWriterFailedPkgs verifies that the packages that had failures are determined correctly
+// even if the content written to the writer is not line-aligned (the writes performed by the "go
+// test" command are not guaranteed to end on a line boundary).
+func TestMultiWriterFailedPkgs(t *testing.T) {
+	const output = `--- FAIL: TestFoo (0.00s)
+    foo_test.go:13: assertion failed
+FAIL
+FAIL	github.com/palantir/project/pkgone	0.021s
+ok  	github.com/palantir/project/pkgtwo	0.004s
+FAIL
+`
+	for _, tc := range []struct {
+		name       string
+		splitAtIdx int
+	}{
+		{
+			name:       "single write",
+			splitAtIdx: len(output),
+		},
+		{
+			name:       "write boundary inside the FAIL summary line",
+			splitAtIdx: bytes.Index([]byte(output), []byte("FAIL\tgithub.com/palantir/project/pkgone")) + 20,
+		},
+		{
+			name:       "write boundary at the start of the FAIL summary line",
+			splitAtIdx: bytes.Index([]byte(output), []byte("FAIL\tgithub.com/palantir/project/pkgone")),
+		},
+		{
+			name:       "write boundary after every byte",
+			splitAtIdx: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var console bytes.Buffer
+			w := &multiWriter{
+				consoleWriter:     &console,
+				rawOutputWriter:   io.Discard,
+				failedPkgs:        []string{},
+				longestPkgNameLen: len("github.com/palantir/project/pkgone"),
+			}
+
+			for remaining := []byte(output); len(remaining) > 0; {
+				currWriteLen := min(tc.splitAtIdx, len(remaining))
+				n, err := w.Write(remaining[:currWriteLen])
+				require.NoError(t, err)
+				require.Equal(t, currWriteLen, n)
+				remaining = remaining[currWriteLen:]
+			}
+			require.NoError(t, w.Flush())
+
+			assert.Equal(t, []string{"github.com/palantir/project/pkgone"}, w.failedPkgs)
+			// all of the content written to the writer must be written to the console exactly once
+			assert.Equal(t, output, console.String())
+		})
+	}
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates the implementation of multiwriter.Write to properly handle multiple calls to write output that are not newline-aligned: adds a buffer so that the logic that processes the written lines actually occurs on newline boundaries.

Previously, if the test runner's "multiwriter.Write" function was written in a way that assumed that all calls to "Write" would be newline-aligned. If calls were not actually newline-aligned then, depending on how the input was split, it was possible that tests cases (and failures) would not properly be parsed.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

